### PR TITLE
Python-level performance improvements in Dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python train.py \
   --lr_steps       10 \
   --lr_alpha       0.3
 ```
-We also modified the weight decay to `1e-5`.
+We also modified the weight decay to `1e-4`.
 
 ## AUC calculation
 The script uses all data for training but AUCs are calculated only on tasks with enough positive and negative examples, default is `25` each.

--- a/sparsechem/data.py
+++ b/sparsechem/data.py
@@ -16,7 +16,8 @@ class SparseDataset(Dataset):
 
         self.x = x.tocsr(copy=False).astype(np.float32)
         self.y = y.tocsr(copy=False).astype(np.float32)
-
+        # scale labels from {-1, -1} to {0, 1}, zeros are stored explicitly
+        self.y.data = (self.y.data + 1) / 2.0
 
     def __len__(self):
         return(self.x.shape[0])
@@ -30,14 +31,21 @@ class SparseDataset(Dataset):
         return self.y.shape[1]
 
     def __getitem__(self, idx):
-        xi = self.x[idx,:]
-        yi = self.y[idx,:]
+        x_start = self.x.indptr[idx]
+        x_end = self.x.indptr[idx + 1]
+        x_indices = self.x.indices[x_start:x_end]
+        x_data = self.x.data[x_start:x_end]
+
+        y_start = self.y.indptr[idx]
+        y_end = self.y.indptr[idx + 1]
+        y_indices = self.y.indices[y_start:y_end]
+        y_data = self.y.data[y_start:y_end]
 
         return {
-            "x_ind":  xi.indices,
-            "x_data": xi.data,
-            "y_ind":  yi.indices,
-            "y_data": yi.data,
+            "x_ind":  x_indices,
+            "x_data": x_data,
+            "y_ind":  y_indices,
+            "y_data": y_data,
         }
 
     def batch_to_x(self, batch, dev):

--- a/sparsechem/utils.py
+++ b/sparsechem/utils.py
@@ -98,7 +98,6 @@ def evaluate_binary(net, loader, loss, dev, progress=True):
                     size = [b["batch_size"], loader.dataset.input_size]).to(dev)
             y_ind  = b["y_ind"].to(dev)
             y_data = b["y_data"].to(dev)
-            y_data = (y_data + 1) / 2.0
 
             y_hat_all = net(X)
             y_hat     = y_hat_all[y_ind[0], y_ind[1]]
@@ -143,7 +142,6 @@ def train_binary(net, optimizer, loader, loss, dev, task_weights, num_int_batche
         y_ind   = b["y_ind"].to(dev)
         y_w     = task_weights[y_ind[1]]
         y_data  = b["y_data"].to(dev)
-        y_data  = (y_data + 1) / 2.0
 
         yhat_all = net(X)
         yhat     = yhat_all[y_ind[0], y_ind[1]]


### PR DESCRIPTION
This PR contains some trivial performance (speed) fixes for Dataset in Sparsechem.

- It avoids the creation of temporary sparse matrices for every element in the minibatch in the `__getitem__` method of the `Dataset` als used by PyTorch's `DataLoader`.
- The binary labels are transformed from {-1, 1} to {0, 1} once when creating the `Dataset` instead of getting transformed for every minibatch anew.

These fixes provide a performance improvement of up to 4x for folded inputs. 99% of the gain is from the elision of sparse temporaries.